### PR TITLE
Added Notification for incoming changes

### DIFF
--- a/ParcelKit/PKSyncManager.h
+++ b/ParcelKit/PKSyncManager.h
@@ -37,6 +37,13 @@ extern NSString * const PKDefaultSyncAttributeName;
 extern NSString * const PKSyncManagerDatastoreStatusDidChangeNotification;
 extern NSString * const PKSyncManagerDatastoreStatusKey;
 
+/**
+ Notification that is posted when the DBDatastore has incoming changes.
+
+ The userInfo of the notification will contain the DBDatastore change NSDictionary in `PKSyncManagerDatastoreStatusKey`
+ */
+extern NSString * const PKSyncManagerDatastoreIncomingChangesNotification;
+extern NSString * const PKSyncManagerDatastoreIncomingChangesKey;
 
 /** 
  The sync manager is responsible for listening to changes from a

--- a/ParcelKit/PKSyncManager.m
+++ b/ParcelKit/PKSyncManager.m
@@ -30,6 +30,8 @@
 NSString * const PKDefaultSyncAttributeName = @"syncID";
 NSString * const PKSyncManagerDatastoreStatusDidChangeNotification = @"PKSyncManagerDatastoreStatusDidChange";
 NSString * const PKSyncManagerDatastoreStatusKey = @"status";
+NSString * const PKSyncManagerDatastoreIncomingChangesNotification = @"PKSyncManagerDatastoreIncomingChanges";
+NSString * const PKSyncManagerDatastoreIncomingChangesKey = @"changes";
 
 static NSUInteger const PKFetchRequestBatchSize = 25;
 
@@ -145,6 +147,10 @@ static NSUInteger const PKFetchRequestBatchSize = 25;
             NSDictionary *changes = [strongSelf.datastore sync:&error];
             if (changes) {
                 [strongSelf updateCoreDataWithDatastoreChanges:changes];
+
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[NSNotificationCenter defaultCenter] postNotificationName:PKSyncManagerDatastoreIncomingChangesNotification object:strongSelf userInfo:@{PKSyncManagerDatastoreIncomingChangesKey: changes}];
+                });
             } else {
                 NSLog(@"Error syncing with Dropbox: %@", error);
             }


### PR DESCRIPTION
Added notification of DBDatastore incoming changes, to allow other classes to lookup changed values.

For our app, we need to synchronise NSUserDefaults with Dropbox as well; since the Dropbox API only allows a datastore to be open once, we need to grab hold of the change dictionary to sync the user defaults.

Great kit btw :+1: 
