### PR TITLE
Fix for entities that do not have sync attribute

### DIFF
--- a/ParcelKit.xcodeproj/project.pbxproj
+++ b/ParcelKit.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		ABE87A4517935C0400E2A1DA /* PKSyncManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ABE87A241793556400E2A1DA /* PKSyncManager.h */; };
 		ABE87A4617935C0400E2A1DA /* NSManagedObject+ParcelKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ABE87A261793556400E2A1DA /* NSManagedObject+ParcelKit.h */; };
 		ABE87A4917935C0400E2A1DA /* DBRecord+ParcelKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = ABE87A281793556400E2A1DA /* DBRecord+ParcelKit.h */; };
+		FEDC67721958C1850057BBEB /* NonSyncableEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = FEDC67711958C1850057BBEB /* NonSyncableEntity.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +149,8 @@
 		ABE87A291793556400E2A1DA /* DBRecord+ParcelKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "DBRecord+ParcelKit.m"; sourceTree = "<group>"; };
 		ABE87A361793558A00E2A1DA /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		ABE87A3A179355F400E2A1DA /* Dropbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Dropbox.framework; sourceTree = "<group>"; };
+		FEDC67701958C1850057BBEB /* NonSyncableEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NonSyncableEntity.h; sourceTree = "<group>"; };
+		FEDC67711958C1850057BBEB /* NonSyncableEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NonSyncableEntity.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +204,8 @@
 				52F5FB16191430470060F8EA /* Author.h */,
 				52F5FB17191430470060F8EA /* Author.m */,
 				AB6EF6771794363500D0BAB0 /* Tests.xcdatamodeld */,
+				FEDC67701958C1850057BBEB /* NonSyncableEntity.h */,
+				FEDC67711958C1850057BBEB /* NonSyncableEntity.m */,
 				AB6EF67D17943D6400D0BAB0 /* NSManagedObjectContext+ParcelKitTests.h */,
 				AB6EF67E17943D6400D0BAB0 /* NSManagedObjectContext+ParcelKitTests.m */,
 				AB6EF6831794783400D0BAB0 /* PKDatastoreMock.h */,
@@ -444,6 +449,7 @@
 				AB1E6AF51795E2BF00FF03A8 /* DBRecord+ParcelKitTests.m in Sources */,
 				ABC7D0FE179360A300AAA1CA /* PKSyncManager.m in Sources */,
 				AB1E6AF01795AD8500FF03A8 /* NSManagedObject+ParcelKitTests.m in Sources */,
+				FEDC67721958C1850057BBEB /* NonSyncableEntity.m in Sources */,
 				AB1E6AF31795D77A00FF03A8 /* PKListMock.m in Sources */,
 				ABC7D102179360AF00AAA1CA /* DBRecord+ParcelKit.m in Sources */,
 				ABC7D0FF179360A700AAA1CA /* NSManagedObject+ParcelKit.m in Sources */,

--- a/ParcelKit/PKSyncManager.m
+++ b/ParcelKit/PKSyncManager.m
@@ -265,6 +265,13 @@ NSString * const PKSyncManagerDatastoreIncomingChangesKey = @"changes";
     [managedObjects unionSet:[managedObjectContext insertedObjects]];
     [managedObjects unionSet:[managedObjectContext updatedObjects]];
     
+    NSSet *managedObjectsCopy = [managedObjects copy];
+    for (NSManagedObject *managedObject in managedObjectsCopy) {
+        if (![managedObject respondsToSelector:NSSelectorFromString(self.syncAttributeName)]) {
+            [managedObjects removeObject:managedObject];
+        }
+    }
+
     NSSet *managedObjectsWithoutSyncId = [managedObjects filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"%K == nil", self.syncAttributeName]];
     for (NSManagedObject *managedObject in managedObjectsWithoutSyncId) {
         [managedObject setPrimitiveValue:[[self class] syncID] forKey:self.syncAttributeName];

--- a/ParcelKitTests/NonSyncableEntity.h
+++ b/ParcelKitTests/NonSyncableEntity.h
@@ -1,0 +1,17 @@
+//
+//  NonSyncableEntity.h
+//  ParcelKit
+//
+//  Created by Liron Yahdav on 6/23/14.
+//  Copyright (c) 2014 Overcommitted, LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+
+@interface NonSyncableEntity : NSManagedObject
+
+@property (nonatomic, retain) NSString * someAttribute;
+
+@end

--- a/ParcelKitTests/NonSyncableEntity.m
+++ b/ParcelKitTests/NonSyncableEntity.m
@@ -1,0 +1,16 @@
+//
+//  NonSyncableEntity.m
+//  ParcelKit
+//
+//  Created by Liron Yahdav on 6/23/14.
+//  Copyright (c) 2014 Overcommitted, LLC. All rights reserved.
+//
+
+#import "NonSyncableEntity.h"
+
+
+@implementation NonSyncableEntity
+
+@dynamic someAttribute;
+
+@end

--- a/ParcelKitTests/PKSyncManagerTests.m
+++ b/ParcelKitTests/PKSyncManagerTests.m
@@ -32,6 +32,7 @@
 #import "PKTableMock.h"
 #import "PKRecordMock.h"
 #import "Author.h"
+#import "NonSyncableEntity.h"
 
 @interface PKSyncManager (ParcelKitTests)
 - (void)updateCoreDataWithDatastoreChanges:(NSDictionary *)changes;
@@ -450,6 +451,15 @@
     DBRecord *record = [table getRecord:@"1" error:nil];
     XCTAssertNotNil(record, @"");
     XCTAssertEqualObjects(@"Harper Lee", [record objectForKey:@"name"], @"");
+}
+
+- (void)testCoreDataInsertShouldNotUpdateDatastoreWithUnsycableObject
+{
+    [self.syncManager startObserving];
+    
+	NonSyncableEntity *object = [NSEntityDescription insertNewObjectForEntityForName:@"NonSyncableEntity" inManagedObjectContext:self.managedObjectContext];
+    [object setValue:@"Foo" forKey:@"someAttribute"];
+    XCTAssertTrue([self.managedObjectContext save:nil], @"");
 }
 
 - (void)testCoreDataInsertWithoutSyncAttributeSpecifiedShouldAddSyncAttribute

--- a/ParcelKitTests/Tests.xcdatamodeld/Tests.xcdatamodel/contents
+++ b/ParcelKitTests/Tests.xcdatamodeld/Tests.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5063" systemVersion="13C64" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13D65" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="Author" representedClassName="Author" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="syncID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
@@ -22,6 +22,9 @@
         <relationship name="authors" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Author" inverseName="books" inverseEntity="Author" syncable="YES"/>
         <relationship name="publisher" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Publisher" inverseName="books" inverseEntity="Publisher" syncable="YES"/>
     </entity>
+    <entity name="NonSyncableEntity" representedClassName="NonSyncableEntity" syncable="YES">
+        <attribute name="someAttribute" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <entity name="Publisher" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="syncID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
@@ -31,5 +34,6 @@
         <element name="Author" positionX="0" positionY="0" width="128" height="90"/>
         <element name="Book" positionX="0" positionY="0" width="128" height="268"/>
         <element name="Publisher" positionX="0" positionY="0" width="128" height="90"/>
+        <element name="NonSyncableEntity" positionX="9" positionY="117" width="128" height="60"/>
     </elements>
 </model>


### PR DESCRIPTION
This is a fix when syncing a data model where some entities don't have a sync attribute. They should be ignored in the logic where setting syncID.
