### PR TITLE
Don't let invalid records prevent the MOC from being saved

### DIFF
--- a/ParcelKit/PKSyncManager.h
+++ b/ParcelKit/PKSyncManager.h
@@ -27,6 +27,13 @@
 #import <CoreData/CoreData.h>
 #import <Dropbox/Dropbox.h>
 
+@class PKSyncManager;
+
+@protocol PKSyncManagerDelegate <NSObject>
+@optional
+- (void)syncManager:(PKSyncManager *)syncManager managedObject:(NSManagedObject *)managedObject insertValidationFailed:(NSError *)error inManagedObjectContext:(NSManagedObjectContext *)managedObjectContext;
+@end
+
 extern NSString * const PKDefaultSyncAttributeName;
 
 /**
@@ -85,6 +92,11 @@ extern NSString * const PKSyncManagerDatastoreLastSyncDateKey;
  The default value is “20”. (2048 KiB max delta size / 100 KiB max record size)
 */
 @property (nonatomic) NSUInteger syncBatchSize;
+
+/**
+ Delegate that can handle various edge cases in an app-specific manner.
+*/
+@property (nonatomic, strong) id<PKSyncManagerDelegate> syncManagerDelegate;
 
 /**
  Returns a random string suitable for using as a sync identifer.

--- a/ParcelKit/PKSyncManager.h
+++ b/ParcelKit/PKSyncManager.h
@@ -96,7 +96,7 @@ extern NSString * const PKSyncManagerDatastoreLastSyncDateKey;
 /**
  Delegate that can handle various edge cases in an app-specific manner.
 */
-@property (nonatomic, strong) id<PKSyncManagerDelegate> syncManagerDelegate;
+@property (nonatomic, weak) id<PKSyncManagerDelegate> delegate;
 
 /**
  Returns a random string suitable for using as a sync identifer.

--- a/ParcelKit/PKSyncManager.m
+++ b/ParcelKit/PKSyncManager.m
@@ -241,12 +241,12 @@ NSString * const PKSyncManagerDatastoreLastSyncDateKey = @"lastSyncDate";
             
             if (managedObject.isInserted) {
                 // Validate this object quickly
-                NSError* error = nil;
+                NSError *error = nil;
                 if (![managedObject validateForInsert:&error]) {
-                    if ((self.syncManagerDelegate != nil) && ([self.syncManagerDelegate respondsToSelector:@selector(syncManager:managedObject:insertValidationFailed:inManagedObjectContext:)])) {
+                    if ((self.delegate != nil) && ([self.delegate respondsToSelector:@selector(syncManager:managedObject:insertValidationFailed:inManagedObjectContext:)])) {
                         
                         // Call the delegate method to respond to this validation error
-                        [self.syncManagerDelegate syncManager:self managedObject:managedObject insertValidationFailed:error inManagedObjectContext:managedObjectContext];
+                        [self.delegate syncManager:self managedObject:managedObject insertValidationFailed:error inManagedObjectContext:managedObjectContext];
                     }
                 }
             }

--- a/ParcelKit/PKSyncManager.m
+++ b/ParcelKit/PKSyncManager.m
@@ -238,6 +238,18 @@ NSString * const PKSyncManagerDatastoreLastSyncDateKey = @"lastSyncDate";
             NSManagedObject *managedObject = update[PKUpdateManagedObjectKey];
             DBRecord *record = update[PKUpdateRecordKey];
             [managedObject pk_setPropertiesWithRecord:record syncAttributeName:strongSelf.syncAttributeName];
+            
+            if (managedObject.isInserted) {
+                // Validate this object quickly
+                NSError* error = nil;
+                if (![managedObject validateForInsert:&error]) {
+                    if ((self.syncManagerDelegate != nil) && ([self.syncManagerDelegate respondsToSelector:@selector(syncManager:managedObject:insertValidationFailed:inManagedObjectContext:)])) {
+                        
+                        // Call the delegate method to respond to this validation error
+                        [self.syncManagerDelegate syncManager:self managedObject:managedObject insertValidationFailed:error inManagedObjectContext:managedObjectContext];
+                    }
+                }
+            }
         }
         
         if ([managedObjectContext hasChanges]) {

--- a/ParcelKitTests/Tests.xcdatamodeld/Tests.xcdatamodel/contents
+++ b/ParcelKitTests/Tests.xcdatamodeld/Tests.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6244" systemVersion="14A361c" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14C109" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="Author" representedClassName="Author" syncable="YES">
         <attribute name="favoriteFood" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -19,7 +19,7 @@
         <attribute name="publishedDate" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="ratingsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="syncID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
-        <attribute name="title" attributeType="String" syncable="YES"/>
+        <attribute name="title" attributeType="String" minValueString="1" syncable="YES"/>
         <attribute name="yearPublished" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <relationship name="authors" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Author" inverseName="books" inverseEntity="Author" syncable="YES"/>
         <relationship name="publisher" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Publisher" inverseName="books" inverseEntity="Publisher" syncable="YES"/>


### PR DESCRIPTION
I'm not sure what you think about this... but I frequently end up in a situation where somehow a single record becomes invalid in the Datastore (usually because a required foreign key constraint is missing) and then the entire ManagedObjectContext refuses to save, and the user ends up with a blank device instead of just a device without the invalid records.
This commit is designed to spot inserts of invalid records and remove them from the MOC before the save happens (they don't get deleted from the Datastore itself)
